### PR TITLE
Corrected testBadHeaderIPN() test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+# Created by .ignore support plugin (hsz.mobi)

--- a/tst/com/amazon/pay/impl/ipn/NotificationVerificationTest.java
+++ b/tst/com/amazon/pay/impl/ipn/NotificationVerificationTest.java
@@ -59,7 +59,7 @@ public class NotificationVerificationTest {
     public void testBadHeaderIPN() {
         Map<String,String> badHeader = new HashMap<String,String>();
         badHeader.put("x-amz-sns-message-type" , "Otherr");
-        NotificationFactory.parseNotification(null, sampleNotification);
+        NotificationFactory.parseNotification(badHeader, sampleNotification);
         Assert.fail();
     }
     


### PR DESCRIPTION
Switched `badHeader` for `null`